### PR TITLE
Lock version of babel-eslint to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/yola/eslint-plugin-yola#readme",
   "dependencies": {
-    "babel-eslint": "8.x",
+    "babel-eslint": "8.0.1",
     "eslint-config-airbnb": "16.x",
     "eslint-config-airbnb-base": "12.x",
     "eslint-plugin-import": "2.x",


### PR DESCRIPTION
Lock version to 8.0.1 because 8.0.2 is using scoped packages in dependencies such as `@babel/traverse` which sinopia can't handle and it breaks down builds.

refs:
- https://github.com/yola/lintreview/pull/70#issuecomment-343418086
- https://github.com/yola/sinopia/pull/11