### PR TITLE
Extend base configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## dev
+
+* Extend base configuration with: 
+  - env variables 
+  - overrides for test files 
+
 ## 0.0.2
 
 * Fix bad release

--- a/src/get-config-base.js
+++ b/src/get-config-base.js
@@ -1,4 +1,30 @@
 module.exports = () => ({
   parser: require.resolve('babel-eslint'),
   plugins: ['yola'],
+  env: {
+    browser: true,
+  },
+  overrides: [
+    {
+      files: [
+        '*-spec.js',
+        '*-spec.jsx',
+        '*.spec.js',
+        '*.spec.jsx',
+      ],
+      env: {
+        mocha: true,
+      },
+      rules: {
+        // Override `import/no-extraneous-dependencies` rule for test files
+        // that should use devDependencies
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: true,
+          },
+        ],
+      },
+    },
+  ],
 });

--- a/src/get-config-base.js
+++ b/src/get-config-base.js
@@ -7,10 +7,10 @@ module.exports = () => ({
   overrides: [
     {
       files: [
-        '*-spec.js',
-        '*-spec.jsx',
-        '*.spec.js',
-        '*.spec.jsx',
+        '**/*-spec.js',
+        '**/*-spec.jsx',
+        '**/*.spec.js',
+        '**/*.spec.jsx',
       ],
       env: {
         mocha: true,

--- a/tests/__snapshots__/index-spec.js.snap
+++ b/tests/__snapshots__/index-spec.js.snap
@@ -4,9 +4,31 @@ exports[`eslint-plugin-yola must contain configs and rules properties 1`] = `
 Object {
   "base": Object {
     "env": Object {
+      "browser": true,
       "es6": true,
       "node": true,
     },
+    "overrides": Array [
+      Object {
+        "env": Object {
+          "mocha": true,
+        },
+        "files": Array [
+          "*-spec.js",
+          "*-spec.jsx",
+          "*.spec.js",
+          "*.spec.jsx",
+        ],
+        "rules": Object {
+          "import/no-extraneous-dependencies": Array [
+            "error",
+            Object {
+              "devDependencies": true,
+            },
+          ],
+        },
+      },
+    ],
     "parser": true,
     "parserOptions": Object {
       "ecmaFeatures": Object {
@@ -329,6 +351,30 @@ Object {
     },
   },
   "react": Object {
+    "env": Object {
+      "browser": true,
+    },
+    "overrides": Array [
+      Object {
+        "env": Object {
+          "mocha": true,
+        },
+        "files": Array [
+          "*-spec.js",
+          "*-spec.jsx",
+          "*.spec.js",
+          "*.spec.jsx",
+        ],
+        "rules": Object {
+          "import/no-extraneous-dependencies": Array [
+            "error",
+            Object {
+              "devDependencies": true,
+            },
+          ],
+        },
+      },
+    ],
     "parser": true,
     "parserOptions": Object {
       "ecmaFeatures": Object {

--- a/tests/create-config-spec.js
+++ b/tests/create-config-spec.js
@@ -4,7 +4,14 @@ const getConfigBase = require('../src/get-config-base');
 const createConfig = require('../src/create-config');
 const propsToPick = require('../src/props-to-pick');
 
-const propsToHave = propsToPick.concat('parser', 'plugins', 'rules');
+const baseProps = [
+  'overrides',
+  'parser',
+  'plugins',
+  'rules',
+];
+
+const propsToHave = propsToPick.concat(baseProps);
 
 describe('createConfig creates extended config', () => {
   const baseConfig = getConfigBase();


### PR DESCRIPTION
At this moment .eslintrc.js is tiny and doesn't covers needs of repos it
used to lint, so to prevent from overriding base configuration files for every repo:

- add proper env to prevent invalid errors about global variables
- override `import/no-extraneous-dependencies` rule for test files that should use devDependencies

refs: https://github.com/yola/lintreview/issues/76