### PR TITLE
Allow use of console.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## dev
+
+* Override base configuration to allow use of `console.error`
+
 ## 0.1.2
 
 * Fix release with failing tests

--- a/src/get-config-base.js
+++ b/src/get-config-base.js
@@ -4,6 +4,16 @@ module.exports = () => ({
   env: {
     browser: true,
   },
+  rules: {
+    'no-console': [
+      'error',
+      {
+        allow: [
+          'error',
+        ],
+      },
+    ],
+  },
   overrides: [
     {
       files: [


### PR DESCRIPTION
 we use console.error in a handful of places, particularly in async code
 where we don't want to throw an error.

refs: https://github.com/yola/sitebuilderui/pull/3924#issuecomment-352814022