### PR TITLE
Fix eslint-import-resolver-typescript version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-yola",
-  "version": "2.3.1-maleks.rc.1",
+  "version": "2.3.1",
   "main": "index.js",
   "scripts": {
     "lint": "eslint -c .eslintrc.js ./",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-yola",
-  "version": "2.3.0",
+  "version": "2.3.1-maleks.rc.1",
   "main": "index.js",
   "scripts": {
     "lint": "eslint -c .eslintrc.js ./",
@@ -26,7 +26,7 @@
     "eslint-config-airbnb": "19.x",
     "eslint-config-airbnb-base": "15.x",
     "eslint-config-prettier": "^10.1.1",
-    "eslint-import-resolver-typescript": "^3.5.5",
+    "eslint-import-resolver-typescript": "3.9.1",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "^6.10.2",


### PR DESCRIPTION
With higher version plugin doesn't work with node@14.

as a part of https://github.com/yola/production/issues/16152